### PR TITLE
Add install for Spack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,5 @@ add_executable(EcoSLIM.exe ${SOURCE})
 if(OpenMP_Fortran_FOUND)
   target_link_libraries(EcoSLIM.exe PUBLIC OpenMP::OpenMP_Fortran)
 endif()
+
+install(TARGETS EcoSLIM.exe DESTINATION bin)


### PR DESCRIPTION
Spack requires an install target.   Will install the EcoSLIM.exe file on a 'make install'